### PR TITLE
Fix config path on macOS

### DIFF
--- a/paaster_cli/__init__.py
+++ b/paaster_cli/__init__.py
@@ -24,7 +24,7 @@ if SYSTEM == "Linux":
 elif SYSTEM == "Windows":
     pathway = f"{getenv('APPDATA')}\\paaster"
 elif SYSTEM == "Darwin":
-    pathway = f"/Users/{getenv('HOME')}/Library/Application Support/paaster"
+    pathway = f"{getenv('HOME')}/Library/Application Support/paaster"
 else:
     raise Exception("Platform not supported.")
 


### PR DESCRIPTION
The `/Users/` was redundant as it is already included in `$HOME`:

```
> echo $HOME
/Users/zac
```

