### PR TITLE
Fix id key on successful upload

### DIFF
--- a/paaster_cli/__init__.py
+++ b/paaster_cli/__init__.py
@@ -142,7 +142,7 @@ def upload(
     )
     if resp.status_code == 201:
         paste: Dict[str, str] = resp.json()
-        url = f"{FRONTEND_URL}{paste['_id']}#{url_unpadded_base64(raw_key)}"
+        url = f"{FRONTEND_URL}{paste['id']}#{url_unpadded_base64(raw_key)}"
 
         if echo_url:
             click.echo(url)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "paaster"
-version = "1.1.10"
+version = "1.1.11"
 description = "Upload locally encrypted pastes from your terminal to Paaster"
 authors = ["WardPearce <wardpearce@protonmail.com>"]
 license = "GPL-3.0"


### PR DESCRIPTION
The key changed fro `_id` to `id`.

Fixes #35.
